### PR TITLE
emacs: fix relative load

### DIFF
--- a/expanderr.el
+++ b/expanderr.el
@@ -1,4 +1,4 @@
 ;; this file provides backwards compatibilty with previously documented way of
 ;; loading this libray in the readme:
 ;; (load "~/go/src/github.com/stapelberg/expanderr/expanderr.el")
-(load "lisp/go-expanderr.el")
+(load-file (expand-file-name "lisp/go-expanderr.el" (file-name-directory load-file-name)))


### PR DESCRIPTION
This should at least cover the load method described in the previous readme.

It will probably fail if `expanderr.el` is byte compiled or invoked in any other way that using `(load)` but that should be ok