### PR TITLE
New custom variable go-expanderr-show-error-buffer

### DIFF
--- a/lisp/go-expanderr.el
+++ b/lisp/go-expanderr.el
@@ -5,6 +5,11 @@
   :type 'string
   :group 'expanderr)
 
+(defcustom go-expanderr-show-error-buffer t
+  "Whether to show a the error buffer when `go-expanderr' failed."
+  :type 'boolean
+  :group 'expanderr)
+
 (defun go-expanderr ()
   "Expand the Call Expression before/under the cursor to check errors."
   (interactive)
@@ -43,7 +48,8 @@
                   (message "Applied expanderr"))
                 (if errbuf (gofmt--kill-error-buffer errbuf)))
             (message "Could not apply expanderr")
-            (if errbuf (gofmt--process-errors (buffer-file-name) tmpfile errbuf))))
+            (when (and errbuf go-expanderr-show-error-buffer)
+	      (gofmt--process-errors (buffer-file-name) tmpfile errbuf))))
 
       (kill-buffer patchbuf)
       (delete-file tmpfile))))


### PR DESCRIPTION
Thanks for creating this nice tool :+1:   The only thing that bothered me while using it was the permanent changing of my window configuration when i called `expanderr` in the wrong place.

`Could not apply expanderr` in the minibuffer is enough information for me.

Setting the new defcustom to nil allows to prevent the display of the error buffer in a
window.

