### PR TITLE
Define key in go-mode-map

### DIFF
--- a/lisp/go-expanderr.el
+++ b/lisp/go-expanderr.el
@@ -54,7 +54,6 @@
       (kill-buffer patchbuf)
       (delete-file tmpfile))))
 
-(add-hook 'go-mode-hook (lambda ()
-			  (local-set-key (kbd "C-c C-e") #'go-expanderr)))
+(define-key go-mode-map (kbd "C-c C-e") #'go-expanderr)
 
 (provide 'go-expanderr)


### PR DESCRIPTION
This makes the "C-c C-e" keybinding visible when using `describe-mode`.